### PR TITLE
Minor fixes and improvements

### DIFF
--- a/lib/shrine/webdav.rb
+++ b/lib/shrine/webdav.rb
@@ -1,4 +1,5 @@
 require 'shrine'
+require 'http'
 
 class Shrine
   module Storage

--- a/lib/shrine/webdav.rb
+++ b/lib/shrine/webdav.rb
@@ -24,8 +24,6 @@ class Shrine
 
       def open(id)
         Down::Http.open(path(@host, id))
-      rescue Down::NotFound => exception
-        raise Error, exception.message
       end
 
       def exists?(id)

--- a/lib/shrine/webdav.rb
+++ b/lib/shrine/webdav.rb
@@ -23,7 +23,7 @@ class Shrine
       end
 
       def open(id)
-        Down.open(path(@host, id))
+        Down::Http.open(path(@host, id))
       rescue Down::NotFound => exception
         raise Error, exception.message
       end

--- a/lib/shrine/webdav.rb
+++ b/lib/shrine/webdav.rb
@@ -1,5 +1,6 @@
 require 'shrine'
 require 'http'
+require 'down/http'
 
 class Shrine
   module Storage
@@ -22,15 +23,9 @@ class Shrine
       end
 
       def open(id)
-        tempfile = Tempfile.new('webdav-', binmode: true)
-        response = HTTP.get(path(@host, id))
-        unless response.code.to_i == 200
-          tempfile.close!
-          raise "downloading of #{path(@host, id)} failed, the server response was #{response}"
-        end
-        tempfile.write(response)
-        tempfile.open
-        tempfile
+        Down.open(path(@host, id))
+      rescue Down::NotFound => exception
+        raise Shrine::Error, exception.message
       end
 
       def exists?(id)

--- a/lib/shrine/webdav.rb
+++ b/lib/shrine/webdav.rb
@@ -15,7 +15,7 @@ class Shrine
         mkpath_to_file(id)
         response = HTTP.put(path(@host, id), body: io.read)
         return if (200..299).cover?(response.code.to_i)
-        raise "uploading of #{path(@host, id)} failed, the server response was #{response}"
+        raise Error, "uploading of #{path(@host, id)} failed, the server response was #{response}"
       end
 
       def url(id, **options)
@@ -25,7 +25,7 @@ class Shrine
       def open(id)
         Down.open(path(@host, id))
       rescue Down::NotFound => exception
-        raise Shrine::Error, exception.message
+        raise Error, exception.message
       end
 
       def exists?(id)
@@ -57,7 +57,7 @@ class Shrine
         dirs.each do |dir|
           response = HTTP.request(:mkcol, "#{@host}#{dir}")
           unless (200..301).cover?(response.code.to_i)
-            raise "creation of directory #{@host}#{dir} failed, the server response was #{response}"
+            raise Error, "creation of directory #{@host}#{dir} failed, the server response was #{response}"
           end
         end
       end

--- a/shrine-webdav.gemspec
+++ b/shrine-webdav.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'shrine', '>= 2.0'
   spec.add_dependency 'http', '~> 2.2', '>= 2.2.2'
+  spec.add_dependency 'down', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/shrine/webdav_spec.rb
+++ b/spec/shrine/webdav_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Shrine::Storage::WebDAV do
       it 'downloads the file and save it to temporary file' do
         stab = stub_request(:get, "#{host}/#{dir}/#{file_name}").to_return(status: 200, body: 'test_content')
         tempfile = subject.open("#{dir}/#{file_name}")
-        expect(tempfile).to be_instance_of(Tempfile)
+        expect(tempfile).to be_instance_of(Down::ChunkedIO)
         expect(tempfile.read).to eq('test_content')
         expect(stab).to have_been_requested
       end
@@ -54,7 +54,7 @@ RSpec.describe Shrine::Storage::WebDAV do
           stab = stub_request(:get, "#{host}/#{dir}/wrong_name").to_return(status: 404)
           subject.open("#{dir}/wrong_name")
           expect(stab).to have_been_requested
-        }.to raise_error(StandardError)
+        }.to raise_error(Shrine::Error)
       end
     end
   end

--- a/spec/shrine/webdav_spec.rb
+++ b/spec/shrine/webdav_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Shrine::Storage::WebDAV do
           stab = stub_request(:get, "#{host}/#{dir}/wrong_name").to_return(status: 404)
           subject.open("#{dir}/wrong_name")
           expect(stab).to have_been_requested
-        }.to raise_error(Shrine::Error)
+        }.to raise_error(Down::NotFound)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
 require 'bundler/setup'
 require 'webmock/rspec'
 require 'shrine/webdav'
+
+# TODO: remove once https://github.com/bblimke/webmock/pull/704 is merged
+class HTTP::Response::Streamer
+  def close
+  end
+end


### PR DESCRIPTION
* Require the HTTP.rb gem.
* Use [Down](https://github.com/janko-m/down) for implementing `#open`; version 3.0 has the HTTP.rb backend which we require with `down/http` and is automatically picked up by `Down.open`, which returns a `Down::ChunkedIO`. If you want a `Tempfile` you can always call `Shrine::UploadedFile#download`, which will internally call `#open` and write the content into a Tempfile.
* Raise `Shrine::Error` instead of `StandardError` for better communication.