### PR TITLE
Use streaming uploads

### DIFF
--- a/lib/shrine/storage/webdav.rb
+++ b/lib/shrine/storage/webdav.rb
@@ -45,7 +45,7 @@ class Shrine
 
       def put(id, io)
         uri = path(@prefixed_host, id)
-        response = HTTP.put(uri, body: io.read)
+        response = HTTP.put(uri, body: io)
         return if (200..299).cover?(response.code.to_i)
         raise Error, "uploading of #{uri} failed, the server response was #{response}"
       end

--- a/shrine-webdav.gemspec
+++ b/shrine-webdav.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'shrine', '>= 2.0'
-  spec.add_dependency 'http', '~> 2.2', '>= 2.2.2'
+  spec.add_dependency 'http', '~> 3.0'
   spec.add_dependency 'down', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'


### PR DESCRIPTION
This upgrades to HTTP.rb 3.0 and switches to using the new streaming IO upload feature. This way the file won't be loaded into memory at once anymore, but instead it will be read chunk-by-chunk. This keeps the memory usage constant during file upload, regardless of the filesize, which is especially useful for larger uploads.