### PR TITLE
Update dependent gem 'down' version

### DIFF
--- a/shrine-webdav.gemspec
+++ b/shrine-webdav.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'shrine', '>= 2.0'
   spec.add_dependency 'http', '~> 3.0'
-  spec.add_dependency 'down', '~> 3.0'
+  spec.add_dependency 'down', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
The newest version of 'shrine' requires gem 'down' version above 4.0.