### PR TITLE
Add the ability to override host in url

### DIFF
--- a/lib/shrine/storage/webdav.rb
+++ b/lib/shrine/storage/webdav.rb
@@ -18,8 +18,9 @@ class Shrine
         put(id, io)
       end
 
-      def url(id, **options)
-        path(@prefixed_host, id)
+      def url(id, host: nil, **options)
+        base_url = path(host || @host, options[:prefix] || @prefix)
+        path(base_url, id)
       end
 
       def open(id)

--- a/spec/shrine/storage/webdav_spec.rb
+++ b/spec/shrine/storage/webdav_spec.rb
@@ -70,6 +70,22 @@ RSpec.describe Shrine::Storage::WebDAV do
     it 'returns file id which is also a path to the file' do
       expect(subject.url(id)).to eq("#{host}/#{id}")
     end
+
+    it 'returns url with specified :host' do
+      custom_host = 'https://cdn.example.com'
+      expect(subject.url(id, host: custom_host)).to eq("#{custom_host}/#{id}")
+    end
+
+    it 'returns url with specified :prefix' do
+      custom_prefix = 'uploads'
+      expect(subject.url(id, prefix: custom_prefix)).to eq("#{host}/#{custom_prefix}/#{id}")
+    end
+
+    it 'returns url with specified :host and :prefix' do
+      custom_host = 'https://cdn.example.com'
+      custom_prefix = 'uploads'
+      expect(subject.url(id, host: custom_host, prefix: custom_prefix)).to eq("#{custom_host}/#{custom_prefix}/#{id}")
+    end
   end
 
   describe '#open' do


### PR DESCRIPTION
Hello guys!
I use this gem in my work with pleasure.
But I have a problem I can't set the custom hostname for uploaded files through plugin: [url_options](https://shrinerb.com/docs/plugins/url_options).
For example:
```ruby
Shrine.storages = {
  cache: Shrine::Storage::WebDAV.new(
    host: 'https://dav.example.com', prefix: 'my_project_name/uploads'
  ),
  store: Shrine::Storage::WebDAV.new(
    host: 'https://dav.example.com', prefix: 'my_project_name/uploads/cache'
  )
}
Shrine.plugin :url_options, store: { host: 'https://cdn.example.com', prefix: 'uploads' }, cache: { host: 'https://cdn.example.com', prefix: 'uploads/cache' }
```
**Expected result for url**: https://cdn.example.com/uploads/cat.jpg
**Actual url**: https://dav.example.com/my_project_name/uploads/cat.jpg

I think my PR will resolve this problem.
Thank you!