### PR TITLE
Fix argument incompatibility with Shrine 3.0

### DIFF
--- a/lib/shrine/storage/webdav.rb
+++ b/lib/shrine/storage/webdav.rb
@@ -24,7 +24,7 @@ class Shrine
         path(base_url, id)
       end
 
-      def open(id)
+      def open(id, **options)
         Down::Http.open(path(@prefixed_host, id)) do |client|
           client.timeout(http_timeout) if http_timeout
           client.basic_auth(http_basic_auth) if http_basic_auth

--- a/shrine-webdav.gemspec
+++ b/shrine-webdav.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'shrine-webdav'
-  spec.version       = '0.2.2'
+  spec.version       = '0.2.3'
   spec.authors       = ['Ivan Kushmantsev', 'Dmitry Efimov']
   spec.email         = ['i.kushmantsev@fun-box.ru', 'tuwilof@gmail.com']
 


### PR DESCRIPTION
The Shrine version specified in the gemspec has been incompatible since the last bump of Dec 2019. The requirement to pass options [was introduced](https://github.com/shrinerb/shrine/commit/62d050e76b2145544fa36d89c0bea1253e5188c2#diff-2ee321166d30a491c9754fed7e80b266c63f1b6c978052f38b2314b91b2f8fcf) in the early 3.0.0 pre-releases. As per developer comment:

> Supporting `Storage#open` that doesn't accept additional options
complicates implementation of Shrine, we better require storage objects
to accept additional options (even if they're not used).

[Also see current documentation](https://shrinerb.com/docs/creating-storages#open)

So what I did is add those options, to remain unused for now.